### PR TITLE
Make cgo happy in go1.6

### DIFF
--- a/repository/transient_commit_log.go
+++ b/repository/transient_commit_log.go
@@ -93,7 +93,10 @@ func (r *TransientCommitLog) Get(txid common.Txnid) (common.OpCode, string, []by
 		return common.OPCODE_INVALID, "", nil, err
 	}
 
-	return common.GetOpCodeFromInt(msg.GetOpCode()), msg.GetKey(), msg.GetContent(), nil
+	// msg is a protobuf object. Directly pointing slices/strings into a struct may cause problems for cgo calls
+	key := string([]byte(msg.GetKey()))
+	content := []byte(string(msg.GetContent()))
+	return common.GetOpCodeFromInt(msg.GetOpCode()), key, content, nil
 }
 
 //


### PR DESCRIPTION
The transient commit log is stored as protobuf messages. When keys and values
are accessed, it returns slices pointing to offsets into a protobuf internal structs.
cgo will not access pointers into a go struct having pointers.

Change-Id: I78e11a291b3bfd02817630f4c48f7f9e795c43c5
